### PR TITLE
Use `pip install -e .[dev]` for all CI test invocations

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,8 +32,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
+        pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: List dependencies
       run: |

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -27,11 +27,11 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install -e .
-        pip install -e .[dev]
+        python -m pip install -e .
+        python -m pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |
-        python -m pytest tests --cov=pandas_ts --cov-report=xml
+        python -m pytest --cov=pandas_ts --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -27,8 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install -e .[dev]
+        pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -32,6 +32,6 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |
-        python -m pytest --cov=pandas_ts --cov-report=xml
+        python -m pytest tests --cov=pandas_ts --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Change Description

Use consistent pip installation steps between smoke test and per-PR CI pytest invocations. This should address path issues when trying to run doctests against files in the ./src directory.